### PR TITLE
add install dependencies to fix import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=[],
+    install_requires=['djangorestframework','djangorestframework-jwt'],
 )


### PR DESCRIPTION
Add installation dependencies to fix the stack trace error: 
`from rest_framework_jwt.settings import api_settings
ImportError: No module named rest_framework_jwt.settings`

Hopefully, this can be updated on PyPi as soon as possible.