### PR TITLE
Fix exceptions on register with existing mail

### DIFF
--- a/graph_auth/apps.py
+++ b/graph_auth/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
 
+
 class GraphauthConfig(AppConfig):
     name = 'graph_auth'

--- a/graph_auth/schema.py
+++ b/graph_auth/schema.py
@@ -15,16 +15,19 @@ from graph_auth.settings import graph_auth_settings
 
 import django.contrib.auth
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
-from django.contrib.auth.tokens import default_token_generator as token_generator
+from django.contrib.auth.tokens\
+    import default_token_generator as token_generator
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
 UserModel = django.contrib.auth.get_user_model()
 
+
 class DynamicUsernameMeta(type):
     def __new__(mcs, classname, bases, dictionary):
         dictionary[UserModel.USERNAME_FIELD] = graphene.String(required=True)
         return type.__new__(mcs, classname, bases, dictionary)
+
 
 class UserNode(DjangoObjectType):
     class Meta:
@@ -36,14 +39,17 @@ class UserNode(DjangoObjectType):
     @classmethod
     def get_node(cls, id, context, info):
         user = super(UserNode, cls).get_node(id, context, info)
-        if context.user.id and (user.id == context.user.id or context.user.is_staff):
+        if context.user.id and (
+                user.id == context.user.id or context.user.is_staff):
             return user
         else:
             return None
 
     token = graphene.String()
+
     def resolve_token(self, args, context, info):
-        if self.id != context.user.id and not getattr(self, 'is_current_user', False):
+        if self.id != context.user.id and\
+                not getattr(self, 'is_current_user', False):
             return None
 
         jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
@@ -53,6 +59,7 @@ class UserNode(DjangoObjectType):
         token = jwt_encode_handler(payload)
 
         return token
+
 
 class RegisterUser(relay.ClientIDMutation):
     class Input(metaclass=DynamicUsernameMeta):
@@ -67,25 +74,33 @@ class RegisterUser(relay.ClientIDMutation):
     @classmethod
     def mutate_and_get_payload(cls, input, context, info):
         model = UserModel
-        if graph_auth_settings.ONLY_ADMIN_REGISTRATION and not (context.user.id and context.user.is_staff):
+        if graph_auth_settings.ONLY_ADMIN_REGISTRATION and not (
+                context.user.id and context.user.is_staff):
             return RegisterUser(ok=False, user=None)
         if 'clientMutationId' in input:
             input.pop('clientMutationId')
         email = input.pop('email')
         username = input.pop(UserModel.USERNAME_FIELD, email)
-        password = input.pop('password') if 'password' in input else model.objects.make_random_password()
+        password = input.pop('password') if 'password' in input\
+            else model.objects.make_random_password()
 
+        if model.objects.filter(email=email):
+            return RegisterUser(ok=False, user=None)
         user = model.objects.create_user(username, email, password, **input)
         user.is_current_user = True
 
-        if graph_auth_settings.WELCOME_EMAIL_TEMPLATE is not None and graph_auth_settings.EMAIL_FROM is not None:
+        if graph_auth_settings.WELCOME_EMAIL_TEMPLATE is not None\
+                and graph_auth_settings.EMAIL_FROM is not None:
             from mail_templated import EmailMessage
             input_data = user.__dict__
             input_data['password'] = password
-            message = EmailMessage(graph_auth_settings.WELCOME_EMAIL_TEMPLATE, input_data, graph_auth_settings.EMAIL_FROM, [user.email])
+            message = EmailMessage(
+                graph_auth_settings.WELCOME_EMAIL_TEMPLATE, input_data,
+                graph_auth_settings.EMAIL_FROM, [user.email])
             message.send()
 
         return RegisterUser(ok=True, user=user)
+
 
 class LoginUser(relay.ClientIDMutation):
     class Input(metaclass=DynamicUsernameMeta):
@@ -111,6 +126,7 @@ class LoginUser(relay.ClientIDMutation):
         else:
             return LoginUser(ok=False, user=None)
 
+
 class ResetPasswordRequest(relay.ClientIDMutation):
     class Input:
         email = graphene.String(required=True)
@@ -119,21 +135,26 @@ class ResetPasswordRequest(relay.ClientIDMutation):
 
     @classmethod
     def mutate_and_get_payload(cls, input, context, info):
-        if graph_auth_settings.CUSTOM_PASSWORD_RESET_TEMPLATE is not None and graph_auth_settings.EMAIL_FROM is not None and graph_auth_settings.PASSWORD_RESET_URL_TEMPLATE is not None:
+        if graph_auth_settings.CUSTOM_PASSWORD_RESET_TEMPLATE is not None\
+            and graph_auth_settings.EMAIL_FROM is not None and\
+                graph_auth_settings.PASSWORD_RESET_URL_TEMPLATE is not None:
 
             from mail_templated import EmailMessage
 
             for user in UserModel.objects.filter(email=input.get('email')):
                 uid = urlsafe_base64_encode(force_bytes(user.pk)).decode()
                 token = token_generator.make_token(user)
-                link = graph_auth_settings.PASSWORD_RESET_URL_TEMPLATE.format(token=token, uid=uid)
+                link = graph_auth_settings.PASSWORD_RESET_URL_TEMPLATE\
+                    .format(token=token, uid=uid)
                 input_data = {
-                    "email": user.email, 
-                    "first_name": user.first_name, 
-                    "last_name": user.last_name, 
+                    "email": user.email,
+                    "first_name": user.first_name,
+                    "last_name": user.last_name,
                     "link": link
-                    }
-                message = EmailMessage(graph_auth_settings.CUSTOM_PASSWORD_RESET_TEMPLATE, input_data, graph_auth_settings.EMAIL_FROM, [user.email])
+                }
+                message = EmailMessage(
+                    graph_auth_settings.CUSTOM_PASSWORD_RESET_TEMPLATE,
+                    input_data, graph_auth_settings.EMAIL_FROM, [user.email])
                 message.send()
 
         else:
@@ -155,6 +176,7 @@ class ResetPasswordRequest(relay.ClientIDMutation):
             reset_form.save(**options)
 
         return ResetPasswordRequest(ok=True)
+
 
 class ResetPassword(relay.ClientIDMutation):
     class Input:
@@ -191,11 +213,13 @@ class ResetPassword(relay.ClientIDMutation):
 
         return ResetPassword(ok=True, user=user)
 
+
 class UpdateUsernameMeta(type):
     def __new__(mcs, classname, bases, dictionary):
         for field in graph_auth_settings.USER_FIELDS:
             dictionary[field] = graphene.String()
         return type.__new__(mcs, classname, bases, dictionary)
+
 
 class UpdateUser(relay.ClientIDMutation):
     class Input(metaclass=UpdateUsernameMeta):
@@ -226,7 +250,7 @@ class UpdateUser(relay.ClientIDMutation):
                 raise Exception("Current password is incorrect.")
 
         for key, value in input.items():
-            if not key is 'current_password':
+            if key is not 'current_password':
                 setattr(user, key, value)
 
         user.save()
@@ -235,13 +259,16 @@ class UpdateUser(relay.ClientIDMutation):
 
         return UpdateUser(ok=True, result=updated_user)
 
+
 class Query(AbstractType):
     user = relay.Node.Field(UserNode)
     users = DjangoFilterConnectionField(UserNode)
 
     me = graphene.Field(UserNode)
+
     def resolve_me(self, args, context, info):
         return UserNode.get_node(context.user.id, context, info)
+
 
 class Mutation(AbstractType):
     register_user = RegisterUser.Field()

--- a/graph_auth/settings.py
+++ b/graph_auth/settings.py
@@ -34,6 +34,7 @@ DEFAULTS = {
 # List of settings that may be in string import notation.
 IMPORT_STRINGS = ()
 
+
 def perform_import(val, setting_name):
     """
     If the given setting is a string import notation,
@@ -103,12 +104,15 @@ class GraphAuthSettings(object):
         setattr(self, attr, val)
         return val
 
+
 graph_auth_settings = GraphAuthSettings(None, DEFAULTS, IMPORT_STRINGS)
+
 
 def reload_graph_auth_settings(*args, **kwargs):
     global graph_auth_settings
     setting, value = kwargs['setting'], kwargs['value']
     if setting == 'GRAPH_AUTH':
         graph_auth_settings = GraphAuthSettings(value, DEFAULTS, IMPORT_STRINGS)
+
 
 setting_changed.connect(reload_graph_auth_settings)


### PR DESCRIPTION
Previous version had a problem with sign up process.
If the user tried to register with email, which already exists in database, exception occured, which so this fragment of code was hard to debug, use and write tests.